### PR TITLE
Use binary open mode for protobuf files

### DIFF
--- a/convert/templight_convert.cpp
+++ b/convert/templight_convert.cpp
@@ -149,7 +149,7 @@ int main(int argc, const char **argv) {
     if( in_files[i] == "-" )
       p_buf = &std::cin;
     else {
-      p_buf = new std::ifstream(in_files[i]);
+      p_buf = new std::ifstream(in_files[i], std::ios_base::in | std::ios_base::binary);
       if( p_buf && !(*p_buf) ) {
         std::cerr << "Warning: [Templight-Convert] Could not open the templight trace file: " << in_files[i] << std::endl;
         delete p_buf;


### PR DESCRIPTION
On Windows templight-convert failed to read some protobuf files which included ASCII 26 characters (Substitute).
This is solved by using binary mode for the ifstream.
