### PR TITLE
Fixed typographical error, changed admitedly to admittedly in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ And for the meta-call-graph:
 
 [![](images/fibonacci_small.o.trace.cg.gv.png)](images/fibonacci.o.trace.cg.gv.png)
 
-This is admitedly rather crude at the moment.
+This is admittedly rather crude at the moment.
 
 ### Inspecting with KCacheGrind
 


### PR DESCRIPTION
@mikael-s-persson, I've corrected a typographical error in the documentation of the [templight-tools](https://github.com/mikael-s-persson/templight-tools) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
